### PR TITLE
Fix Repo URL

### DIFF
--- a/TeamcraftListMaker.json
+++ b/TeamcraftListMaker.json
@@ -6,7 +6,7 @@
   "ApplicableVersion": "any",
   "Punchline": "Adds a new menu when right clicking items that lets you easily add/remove items to a list and then export it to Teamcraft",
   "Description": "No more alt tabbing, no more writing down names of items, just add and export!\n\nThis plugin is not created by Teamcraft staff and they are not responsible for it. To report issues or request new features, please click the globe icon and submit them using the issues tab.\n\n(Logo used with permission from Teamcraft owner)",
-  "RepoUrl": "hhttps://github.com/Aida-Enna/TeamcraftListMaker",
+  "RepoUrl": "https://github.com/Aida-Enna/TeamcraftListMaker",
   "Tags": [
     "teamcraft",
     "craft",


### PR DESCRIPTION
The Repo URL had an extra H making the link nonfunctional in the Plugin Browser.